### PR TITLE
Enable parallel fetches from server using multiple threads

### DIFF
--- a/src/main/java/io/takari/aether/connector/AetherRepositoryConnector.java
+++ b/src/main/java/io/takari/aether/connector/AetherRepositoryConnector.java
@@ -319,7 +319,7 @@ class AetherRepositoryConnector implements RepositoryConnector {
     for (Future<?> future : futures) {
       try {
         future.get();
-      } catch (InterruptedException |ExecutionException e) {
+      } catch (InterruptedException | ExecutionException e) {
         Throwables.propagate(e);
       }
     }

--- a/src/main/java/io/takari/aether/connector/AetherRepositoryConnector.java
+++ b/src/main/java/io/takari/aether/connector/AetherRepositoryConnector.java
@@ -92,8 +92,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-//import org.eclipse.aether.spi.log.Logger;
-
 class AetherRepositoryConnector implements RepositoryConnector {
   private static final Map<String, String> checksumAlgos;
 


### PR DESCRIPTION
This is vastly superior to single threaded download purely because of the slowness of file IO. Here is a benchmark on naked OK client:
https://gist.github.com/dhanji/b441939e647096dbaeda

I have only modified GET as we probably don't want to generate spiky loads on nexus.
