### PR TITLE
Fix okhttp trustManager refelection not supported in java9

### DIFF
--- a/src/main/java/io/takari/aether/client/AetherClientConfig.java
+++ b/src/main/java/io/takari/aether/client/AetherClientConfig.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509TrustManager;
 
 public class AetherClientConfig {
   
@@ -75,6 +76,8 @@ public class AetherClientConfig {
 
   private SSLSocketFactory sslSocketFactory;
 
+  private X509TrustManager trustManager;
+
   private HostnameVerifier hostnameVerifier;
   
   public SSLSocketFactory getSslSocketFactory() {
@@ -83,6 +86,14 @@ public class AetherClientConfig {
 
   public void setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
     this.sslSocketFactory = sslSocketFactory;
+  }
+
+  public X509TrustManager getTrustManager() {
+    return trustManager;
+  }
+
+  public void setTrustManager(X509TrustManager trustManager) {
+    this.trustManager = trustManager;
   }
 
   public HostnameVerifier getHostnameVerifier() {

--- a/src/main/java/io/takari/aether/connector/AetherRepositoryConnector.java
+++ b/src/main/java/io/takari/aether/connector/AetherRepositoryConnector.java
@@ -53,6 +53,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.X509TrustManager;
 
 import org.codehaus.plexus.configuration.PlexusConfiguration;
 import org.eclipse.aether.ConfigurationProperties;
@@ -163,10 +164,11 @@ class AetherRepositoryConnector implements RepositoryConnector {
   }
 
   public AetherRepositoryConnector(RemoteRepository repository, RepositorySystemSession session, FileProcessor fileProcessor) throws NoRepositoryConnectorException {
-    this(repository, session, fileProcessor, null);
+    this(repository, session, fileProcessor, null, null);
   }
 
-  public AetherRepositoryConnector(RemoteRepository repository, RepositorySystemSession session, FileProcessor fileProcessor, SSLSocketFactory sslSocketFactory) throws NoRepositoryConnectorException {
+  public AetherRepositoryConnector(RemoteRepository repository, RepositorySystemSession session, FileProcessor fileProcessor, SSLSocketFactory sslSocketFactory,
+		  X509TrustManager trustManager) throws NoRepositoryConnectorException {
     //
     // Right now this only support a Maven layout which is what we mean by type
     //
@@ -188,11 +190,11 @@ class AetherRepositoryConnector implements RepositoryConnector {
       throw new NoRepositoryConnectorException(repository, e);
     }
 
-    this.aetherClient = newAetherClient(repository, session, sslSocketFactory);
+    this.aetherClient = newAetherClient(repository, session, sslSocketFactory, trustManager);
   }
 
   private static OkHttpAetherClient newAetherClient(RemoteRepository repository, RepositorySystemSession session,
-      SSLSocketFactory sslSocketFactory) {
+      SSLSocketFactory sslSocketFactory, X509TrustManager trustManager) {
     AetherClientConfig config = new AetherClientConfig();
 
     Map<String, String> commonHeaders = new HashMap<>();
@@ -272,6 +274,7 @@ class AetherRepositoryConnector implements RepositoryConnector {
     config.setConnectionTimeout(connectTimeout);
     config.setRequestTimeout(readTimeout);
     config.setSslSocketFactory(sslSocketFactory);
+    config.setTrustManager(trustManager);
 
     return new OkHttpAetherClient(config);
   }

--- a/src/main/java/io/takari/aether/connector/AetherRepositoryConnectorFactory.java
+++ b/src/main/java/io/takari/aether/connector/AetherRepositoryConnectorFactory.java
@@ -10,13 +10,21 @@
  *******************************************************************************/
 package io.takari.aether.connector;
 
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
 
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
@@ -34,12 +42,13 @@ import org.eclipse.sisu.Nullable;
 @Named("okhttp")
 @Singleton
 public final class AetherRepositoryConnectorFactory implements RepositoryConnectorFactory, Service {
-  
+
   // see org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout
   private static final String LAYOUT_DEFAULT = "default";
 
   private FileProcessor fileProcessor;
   private final SSLSocketFactory sslSocketFactory;
+  private final X509TrustManager trustManager;
 
   private static final class ConnectorKey {
     private final RemoteRepository repository;
@@ -59,34 +68,100 @@ public final class AetherRepositoryConnectorFactory implements RepositoryConnect
     }
   }
 
-  // Default constructor required for the service locator to work with you use this factory outside the confines of Guice.
-  public  AetherRepositoryConnectorFactory() throws NoSuchAlgorithmException {
-    this(null, null);
+  // Default constructor required for the service locator to work with you use
+  // this factory outside the confines of Guice.
+  public AetherRepositoryConnectorFactory() throws NoSuchAlgorithmException {
+    this(null, null, null);
   }
-  
+
   @Inject
-  public AetherRepositoryConnectorFactory(FileProcessor fileProcessor, @Nullable SSLSocketFactory sslSocketFactory) throws NoSuchAlgorithmException {
+  public AetherRepositoryConnectorFactory(FileProcessor fileProcessor, @Nullable SSLSocketFactory sslSocketFactory,
+      @Nullable X509TrustManager trustManager) throws NoSuchAlgorithmException {
     this.fileProcessor = fileProcessor;
-    
-    // explicitly use jdk-default ssl socket factory if none is provided externally
+
+    // explicitly create new ssl socket factory if none is provided externally
     // this is necessary because okhttp default socket factory does not honour
-    // javax.net.ssl.keyStore/trustStore system properties, which are the only way
+    // javax.net.ssl.keyStore/trustStore system properties, which are the only
+    // way
     // to use custom ket/trust stores in maven in m2e
-    this.sslSocketFactory = sslSocketFactory != null? sslSocketFactory: SSLContext.getDefault().getSocketFactory();
+    if (sslSocketFactory != null && trustManager != null) {
+      this.sslSocketFactory = sslSocketFactory;
+      this.trustManager = trustManager;
+    } else {
+      // can not use use jdk-default ssl socket factory like previous because
+      // we can not get trust manager without reflection
+      try {
+        String trustManagerFactoryAlgorithm = TrustManagerFactory.getDefaultAlgorithm();
+        TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(trustManagerFactoryAlgorithm);
+        trustManagerFactory.init((KeyStore) null);
+
+				String keyStoreProviderProp = System.getProperty("javax.net.ssl.keyStoreProvider");
+				String keyStoreProp = System.getProperty("javax.net.ssl.keyStore");
+				String keyStoreTypeProp = System.getProperty("javax.net.ssl.keyStoreType", KeyStore.getDefaultType());
+				String keyStorePasswordProp = System.getProperty("javax.net.ssl.keyStorePassword");
+
+				// TODO more key store arguments combination check
+				if (caseInsensitiveEequals(keyStoreTypeProp, "PKCS11") && caseInsensitiveEequals(keyStoreProp, "NONE"))
+					throw new IllegalArgumentException(
+					    "Illegal key store arguments combination (keyStoreTypeProp PKCS11): keyStoreProp can not be NONE");
+
+				char[] password = isEmpty(keyStorePasswordProp) ? null : keyStorePasswordProp.toCharArray();
+
+				KeyStore keyStore;
+				if (isEmpty(keyStoreTypeProp))
+					keyStore = null;
+				else {
+					keyStore = isEmpty(keyStoreProviderProp) ? KeyStore.getInstance(keyStoreTypeProp)
+					    : KeyStore.getInstance(keyStoreTypeProp, keyStoreProviderProp);
+
+          if (!isEmpty(keyStoreProp) && !caseInsensitiveEequals(keyStoreProp, "NONE")) {
+            try (InputStream stream = new FileInputStream(keyStoreProp)) {
+              keyStore.load(stream, password);
+            }
+          } else
+            keyStore.load(null, password);
+        }
+
+        String keyManagerFactoryAlgorithm = KeyManagerFactory.getDefaultAlgorithm();
+        KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(keyManagerFactoryAlgorithm);
+
+        keyManagerFactory.init(keyStore, caseInsensitiveEequals(keyStoreTypeProp, "PKCS11") ? null : password);
+
+        TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
+        KeyManager[] keyManagers = keyManagerFactory.getKeyManagers();
+
+        SSLContext sslContext = SSLContext.getInstance("SSL");
+        sslContext.init(keyManagers, trustManagers, null);
+        this.sslSocketFactory = sslContext.getSocketFactory();
+        this.trustManager = (X509TrustManager) trustManagers[0];
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  private boolean caseInsensitiveEequals(String s1, String s2) {
+    return (s1 == s2) || (s1 != null && s1.equalsIgnoreCase(s2));
+  }
+
+  private boolean isEmpty(String s) {
+    return s == null || s.isEmpty();
   }
 
   public float getPriority() {
     return 100; // let other factories take over, if they want to
   }
 
-  public RepositoryConnector newInstance(RepositorySystemSession repositorySystemSession, RemoteRepository remoteRepository) throws NoRepositoryConnectorException {
+  public RepositoryConnector newInstance(RepositorySystemSession repositorySystemSession,
+      RemoteRepository remoteRepository) throws NoRepositoryConnectorException {
     if (!LAYOUT_DEFAULT.equals(remoteRepository.getContentType())) {
       throw new NoRepositoryConnectorException(remoteRepository);
     }
     ConnectorKey key = new ConnectorKey(remoteRepository);
     RepositoryConnector connector = (RepositoryConnector) repositorySystemSession.getData().get(key);
     if (connector == null) {
-      connector = new AetherRepositoryConnector(remoteRepository, repositorySystemSession, fileProcessor, sslSocketFactory);
+      connector = new AetherRepositoryConnector(remoteRepository, repositorySystemSession, fileProcessor,
+          sslSocketFactory, trustManager);
       if (!repositorySystemSession.getData().set(key, null, connector)) {
         connector = (RepositoryConnector) repositorySystemSession.getData().get(key);
       }

--- a/src/main/java/io/takari/aether/connector/AetherRepositoryConnectorFactory.java
+++ b/src/main/java/io/takari/aether/connector/AetherRepositoryConnectorFactory.java
@@ -94,8 +94,7 @@ public final class AetherRepositoryConnectorFactory implements RepositoryConnect
       // ssl socket factory.
       try {
         String trustManagerFactoryAlgorithm = TrustManagerFactory.getDefaultAlgorithm();
-        // Clearly specify TrustManagerFactory provider to SunJSSE.
-        TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(trustManagerFactoryAlgorithm, "SunJSSE");
+        TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(trustManagerFactoryAlgorithm);
         trustManagerFactory.init((KeyStore) null);
         if (!(trustManagerFactory.getTrustManagers()[0] instanceof X509TrustManager))
           throw new UnsupportedOperationException("Only X509TrustManager supported by implementation");

--- a/src/main/java/io/takari/aether/okhttp/OkHttpAetherClient.java
+++ b/src/main/java/io/takari/aether/okhttp/OkHttpAetherClient.java
@@ -94,8 +94,8 @@ public class OkHttpAetherClient implements AetherClient {
         .proxyAuthenticator(PROXY_AUTH) //
         .connectTimeout(config.getConnectionTimeout(), TimeUnit.MILLISECONDS) //
         .readTimeout(config.getRequestTimeout(), TimeUnit.MILLISECONDS);
-    if (config.getSslSocketFactory() != null) {
-      builder.sslSocketFactory(config.getSslSocketFactory());
+    if (config.getSslSocketFactory() != null && config.getTrustManager() != null) {
+      builder.sslSocketFactory(config.getSslSocketFactory(), config.getTrustManager());
     }
     if (config.getHostnameVerifier() != null) {
       builder.hostnameVerifier(config.getHostnameVerifier());

--- a/src/test/java/io/takari/aether/connector/test/mockwebserver/AetherMockWebserverConnectorTest.java
+++ b/src/test/java/io/takari/aether/connector/test/mockwebserver/AetherMockWebserverConnectorTest.java
@@ -410,6 +410,7 @@ public class AetherMockWebserverConnectorTest extends InjectedTestCase {
     config.setAuthentication(auth);
     config.setProxy(proxy);
     config.setSslSocketFactory(sslClient.socketFactory);
+    config.setTrustManager(sslClient.trustManager);
     config.setHostnameVerifier(hostnameVerifier);
 
     OkHttpAetherClient aetherClient = new OkHttpAetherClient(config);
@@ -496,6 +497,7 @@ public class AetherMockWebserverConnectorTest extends InjectedTestCase {
     config.setAuthentication(auth);
     config.setProxy(proxy);
     config.setSslSocketFactory(sslClient.socketFactory);
+    config.setTrustManager(sslClient.trustManager);
     config.setHostnameVerifier(hostnameVerifier);
     
     OkHttpAetherClient aetherClient = new OkHttpAetherClient(config);


### PR DESCRIPTION
Fixed UnsupportedOperationException occurs in jdk9.
Addition information: https://bugs.eclipse.org/bugs/show_bug.cgi?id=517113