### PR TITLE
#15 - Fix for the race condition in Aether connector

### DIFF
--- a/src/main/java/io/takari/aether/connector/AetherRepositoryConnector.java
+++ b/src/main/java/io/takari/aether/connector/AetherRepositoryConnector.java
@@ -81,7 +81,6 @@ import com.google.common.io.Closer;
 
 // Resumable downloads
 // http://zoompf.com/2010/03/performance-tip-for-http-downloads
-// http://stackoverflow.com/questions/6237079/resume-http-file-download-in-java
 
 import io.takari.aether.client.AetherClient;
 import io.takari.aether.client.AetherClientAuthentication;
@@ -559,54 +558,20 @@ class AetherRepositoryConnector implements RepositoryConnector {
       long bytesTransferred = 0;
 
       boolean downloadSuccessful = false;
-      boolean resumeDownloadInProgress = false;
       File temporaryFileInLocalRepository = null;
 
       //
       // Need to distinguish between client side failure and server side failure
       //      
       for (int retries = 0; retries < 10; retries++) {
-        File[] files = fileInLocalRepository.getParentFile().listFiles();
-        for (File inProgress : files) {
-          //
-          // ${HOME}/.m2/repository/io/tesla/tesla/4/aether-737f90e4cfa047e3-pom.xml-in-progress
-          //
-          if (inProgress.getName().startsWith("aether") && inProgress.getName().endsWith(fileInLocalRepository.getName() + "-in-progress")) {
-            temporaryFileInLocalRepository = inProgress;
-            resumeDownloadInProgress = true;
-            break;
-          }
-        }
-
-        if (temporaryFileInLocalRepository == null) {
-          temporaryFileInLocalRepository = getTmpFile(fileInLocalRepository.getPath());
-        }
+        temporaryFileInLocalRepository = getTmpFile(fileInLocalRepository.getPath());
 
         //JVZ: this all needs to be moved up to the client
 
-        try (Response response = getResponse(uri, resumeDownloadInProgress, temporaryFileInLocalRepository);
+        try (Response response = getResponse(uri,temporaryFileInLocalRepository);
             InputStream is = response.getInputStream()) {
 
         handleResponseCode(uri, response.getStatusCode(), response.getStatusMessage());
-        //
-        // We need to check to see if the server supports the Range header. We should see a response
-        // that looks like the following:
-        //
-        // 206 Partial Content
-        // Content-Type: video/mp4
-        // Content-Length: 64656927
-        // Accept-Ranges: bytes
-        // Content-Range: bytes 100-64656926/64656927
-        //
-        //
-        // If we are going to resume a download, the server needs to respond with a 206 and say it accepts ranges
-        //                
-        if (resumeDownloadInProgress && response.getHeader("Accept-Ranges") == null && response.getStatusCode() == HttpURLConnection.HTTP_OK) {
-          //
-          // The server does not support ranges so delete the temporary file and start over.
-          //
-          temporaryFileInLocalRepository.delete();
-        }
 
         if (emitProgressEvent) {
           String contentLength = response.getHeader("Content-Length");
@@ -620,7 +585,7 @@ class AetherRepositoryConnector implements RepositoryConnector {
         final byte[] buffer = new byte[1024 * 1024];
         int n = 0;
 
-          try (OutputStream os = new BufferedOutputStream(new FileOutputStream(temporaryFileInLocalRepository, resumeDownloadInProgress))) {
+          try (OutputStream os = new BufferedOutputStream(new FileOutputStream(temporaryFileInLocalRepository))) {
             while (-1 != (n = is.read(buffer))) {
               os.write(buffer, 0, n);
               if (emitProgressEvent) {
@@ -656,22 +621,9 @@ class AetherRepositoryConnector implements RepositoryConnector {
       return new FileTransfer(temporaryFileInLocalRepository, bytesTransferred);
     }
 
-    private Response getResponse(String uri, boolean resumeDownloadInProgress, File temporaryFileInLocalRepository)
+    private Response getResponse(String uri, File temporaryFileInLocalRepository)
             throws IOException {
-      Response response;
-      if (resumeDownloadInProgress) {
-        Map<String, String> requestHeaders = new HashMap<String, String>();
-        requestHeaders.put("Range", "bytes=" + temporaryFileInLocalRepository.length() + "-");
-        requestHeaders.put("Accept-Encoding", "identity");
-        response = aetherClient.get(uri, requestHeaders);
-        if (response.getStatusCode() == 416) {
-          response.close();
-          response = aetherClient.get(uri);
-        }
-      } else {
-        response = aetherClient.get(uri);
-      }
-      return response;
+      return aetherClient.get(uri);
     }
 
     public void flush() {

--- a/src/test/java/io/takari/aether/connector/test/suite/ConcurrentDownloadTest.java
+++ b/src/test/java/io/takari/aether/connector/test/suite/ConcurrentDownloadTest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2012 to original author or authors
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package io.takari.aether.connector.test.suite;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.internal.impl.DefaultFileProcessor;
+import org.eclipse.aether.repository.RepositoryPolicy;
+import org.eclipse.aether.spi.connector.ArtifactDownload;
+import org.eclipse.aether.spi.connector.MetadataDownload;
+import org.eclipse.aether.spi.connector.RepositoryConnector;
+import org.eclipse.aether.spi.io.FileProcessor;
+import org.eclipse.aether.util.ChecksumUtils;
+
+import com.google.inject.Binder;
+
+public class ConcurrentDownloadTest extends AetherTestCase {
+  private static final int NUMBER_OF_TRIES_TO_CAUSE_CORRUPTION = 10;
+  private static final int NUMBER_OF_THREADS = 2;
+  private static final File TMP = new File(System.getProperty("java.io.tmpdir"), "aether-" + UUID.randomUUID().toString().substring(0, 8));
+
+  @Override
+  public void configure(Binder binder) {
+    binder.bind(FileProcessor.class).to(DefaultFileProcessor.class);
+    super.configure(binder);
+  }
+
+  /**
+   * See https://github.com/takari/aether-connector-okhttp/issues/15
+   */
+  public void testConcurrentDownloadOfSameFileShouldNotCorruptDownloadedArtifact() throws Exception {
+    String testInput = createTestInput();
+    String expectedChecksum = sha1(testInput);
+
+    addDelivery("gid/aid/version/aid-version-classifier.extension", testInput.getBytes());
+    addDelivery("gid/aid/version/aid-version-classifier.extension.sha1", expectedChecksum.getBytes());
+
+    File file = new File(TMP, "foo-bar-1.0.pom");
+    Artifact artifact = artifact();
+    ArtifactDownload down = new ArtifactDownload(artifact, null, file, RepositoryPolicy.CHECKSUM_POLICY_WARN);
+    Collection<? extends ArtifactDownload> downs = Arrays.asList(down);
+    RepositoryConnector connector = connector();
+
+    for (int i = 0; i < NUMBER_OF_TRIES_TO_CAUSE_CORRUPTION; ++i) {
+      clearRepo();
+
+      callAetherConnectorWithMultipleThreads(connector, downs);
+
+      String actualChecksum = (String) ChecksumUtils.calc(file, Collections.singleton("SHA-1")).get("SHA-1");
+      assertEquals(expectedChecksum, actualChecksum);
+    }
+  }
+
+  private String createTestInput() {
+    // Create a test input close to the size of a real artifact, so that it is several times
+    // larger than the chunk size of the server to increase the chance of corruption.
+    String result = "";
+    for (int i = 0; i < 100; ++i) {
+      result += "0123456789";
+    }
+    return result;
+  }
+
+  public void clearRepo() {
+    if (TMP.listFiles() != null) {
+      for (File file : TMP.listFiles()) {
+        file.delete();
+      }
+    }
+  }
+
+  private void callAetherConnectorWithMultipleThreads(final RepositoryConnector connector, final Collection<? extends ArtifactDownload> downs) throws InterruptedException {
+    List<Thread> threads = createConnectorCallingThreads(connector, downs);
+    startThreads(threads);
+    waitForThreadsToFinish(threads);
+  }
+
+  private List<Thread> createConnectorCallingThreads(final RepositoryConnector connector, final Collection<? extends ArtifactDownload> downs) {
+    List<Thread> threads = new ArrayList<>();
+    for (int i = 0; i < NUMBER_OF_THREADS; ++i) {
+      threads.add(new Thread(new Runnable() {
+        @Override
+        public void run() {
+          download(connector, downs);
+        }
+      }));
+    }
+    return threads;
+  }
+
+  private void startThreads(List<Thread> threads) {
+    for (Thread thread : threads) {
+      thread.start();
+    }
+  }
+
+  private void waitForThreadsToFinish(List<Thread> threads) throws InterruptedException {
+    for (Thread thread : threads) {
+      thread.join();
+    }
+  }
+
+  private void download(RepositoryConnector connector, Collection<? extends ArtifactDownload> downs) {
+    connector.get(downs, new ArrayList<MetadataDownload>());
+  }
+
+}

--- a/src/test/java/io/takari/aether/connector/test/suite/FlakyHandler.java
+++ b/src/test/java/io/takari/aether/connector/test/suite/FlakyHandler.java
@@ -77,7 +77,7 @@ class FlakyHandler extends AbstractHandler {
         throw new IOException("oups, we're dead");
       }
 
-      out.write(GetResumeTest.CONTENT_PATTERN[i % GetResumeTest.CONTENT_PATTERN.length]);
+      out.write(GetRetryTest.CONTENT_PATTERN[i % GetRetryTest.CONTENT_PATTERN.length]);
     }
 
     out.close();

--- a/src/test/java/io/takari/aether/connector/test/suite/FlakyServerHandlerWithNoRangeSupport.java
+++ b/src/test/java/io/takari/aether/connector/test/suite/FlakyServerHandlerWithNoRangeSupport.java
@@ -56,13 +56,13 @@ class FlakyServerHandlerWithNoRangeSupport extends AbstractHandler {
     if(attempts.intValue() == requiredRequests) {
       // Write out all the content
       for (int i = 0; i < totalSize; i++) {
-        out.write(GetResumeTest.CONTENT_PATTERN[i % GetResumeTest.CONTENT_PATTERN.length]);        
+        out.write(GetRetryTest.CONTENT_PATTERN[i % GetRetryTest.CONTENT_PATTERN.length]);        
         out.flush();
       }
     } else {
       // Write out half the content and die
       for (int i = 0; i <= (totalSize/2); i++) {
-        out.write(GetResumeTest.CONTENT_PATTERN[i % GetResumeTest.CONTENT_PATTERN.length]);        
+        out.write(GetRetryTest.CONTENT_PATTERN[i % GetRetryTest.CONTENT_PATTERN.length]);        
       }      
       throw new IOException("oups, we're dead");
     }

--- a/src/test/java/io/takari/aether/okhttp/OkHttpAetherTest.java
+++ b/src/test/java/io/takari/aether/okhttp/OkHttpAetherTest.java
@@ -10,6 +10,7 @@ package io.takari.aether.okhttp;
 import io.takari.aether.connector.test.mockwebserver.AetherMockWebserverConnectorTest;
 import io.takari.aether.connector.test.suite.AetherConnectorFactoryTest;
 import io.takari.aether.connector.test.suite.AetherConnectorTest;
+import io.takari.aether.connector.test.suite.ConcurrentDownloadTest;
 import io.takari.aether.connector.test.suite.GetAuthSslTest;
 import io.takari.aether.connector.test.suite.GetAuthTest;
 import io.takari.aether.connector.test.suite.GetAuthWithNonAsciiCredentialsTest;
@@ -19,7 +20,7 @@ import io.takari.aether.connector.test.suite.GetProxyAuthTest;
 import io.takari.aether.connector.test.suite.GetProxySslTest;
 import io.takari.aether.connector.test.suite.GetProxyTest;
 import io.takari.aether.connector.test.suite.GetRedirectTest;
-import io.takari.aether.connector.test.suite.GetResumeTest;
+import io.takari.aether.connector.test.suite.GetRetryTest;
 import io.takari.aether.connector.test.suite.GetSslTest;
 import io.takari.aether.connector.test.suite.GetStutteringTest;
 import io.takari.aether.connector.test.suite.GetTest;
@@ -30,7 +31,7 @@ import io.takari.aether.connector.test.suite.PutAuthWithNonAsciiCredentialsTest;
 import io.takari.aether.connector.test.suite.PutProxyTest;
 import io.takari.aether.connector.test.suite.PutSslTest;
 import io.takari.aether.connector.test.suite.PutTest;
-import io.takari.aether.connector.test.suite.ResumeWithClientFailureTest;
+import io.takari.aether.connector.test.suite.RestartDownloadWithClientFailureTest;
 import io.takari.aether.connector.test.suite.TimeoutTest;
 import io.takari.aether.connector.test.suite.WagonTest;
 import junit.framework.TestSuite;
@@ -64,8 +65,8 @@ public class OkHttpAetherTest extends InjectedTestCase {
     suite.addTestSuite(GetProxyAuthTest.class);
     suite.addTestSuite(GetProxyAuthSslTest.class);
     suite.addTestSuite(GetAuthWithNonAsciiCredentialsTest.class);
-    suite.addTestSuite(GetResumeTest.class);
-    suite.addTestSuite(ResumeWithClientFailureTest.class);    
+    suite.addTestSuite(GetRetryTest.class);
+    suite.addTestSuite(RestartDownloadWithClientFailureTest.class);    
     suite.addTestSuite(GetStutteringTest.class);
     //
     // PUT
@@ -97,6 +98,7 @@ public class OkHttpAetherTest extends InjectedTestCase {
 
     // bits and pieces
     suite.addTestSuite(AetherConnectorFactoryTest.class);
+    suite.addTestSuite(ConcurrentDownloadTest.class);
 
     return suite;
   }


### PR DESCRIPTION
PR for #15 
In this PR the resume download feature was removed, because it causes artifact corruption when using multiple threads as discussed in the related issue issue ticket and in 534228 Eclipse bug.
Additional test is added that fails when the resume download feature is used in multiple threads due to the corruptions in the artifacts and passed without it.

Don't merge, as I have yet to post the CLA, will try to do that in the coming days, till then, feel free to review and give me feedback.