### PR TITLE
Restore TLSv1.x compatibility

### DIFF
--- a/src/main/java/io/takari/aether/okhttp/OkHttpAetherClient.java
+++ b/src/main/java/io/takari/aether/okhttp/OkHttpAetherClient.java
@@ -16,6 +16,7 @@ import java.net.SocketAddress;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +33,7 @@ import io.takari.aether.client.AetherClientProxy;
 import io.takari.aether.client.Response;
 import io.takari.aether.client.RetryableSource;
 import okhttp3.Authenticator;
+import okhttp3.ConnectionSpec;
 import okhttp3.Credentials;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -99,6 +101,7 @@ public class OkHttpAetherClient implements AetherClient {
     }
 
     OkHttpClient.Builder builder = new OkHttpClient.Builder() //
+    	.connectionSpecs(Arrays.asList(ConnectionSpec.COMPATIBLE_TLS, ConnectionSpec.CLEARTEXT))//Fixes https://github.com/takari/aether-connector-okhttp/issues/20
         .proxy(getProxy(config.getProxy())) //
         .hostnameVerifier(OkHostnameVerifier.INSTANCE) //
         // TODO looks odd, why do I need to use the same Authenticator twice?


### PR DESCRIPTION
Restores TLSv1.x support that was removed from the default connection specs in [OkHttp 3.13.0](
https://github.com/square/okhttp/blob/master/CHANGELOG.md#version-3130).

Can't figure out how to mock TLS connections in unit tests, but I smoke tested the changes work against 
https://repo.eclipse.org/content/repositories/maven_central/ (as a Maven Central mirror).

Fixes #20